### PR TITLE
Ping the heroku server every 5 min to keep process awake

### DIFF
--- a/slackbot/slack.go
+++ b/slackbot/slack.go
@@ -485,11 +485,24 @@ func HerokuServer() {
 	}
 }
 
+// HerokuPing hits the heroku endpoint every 5 min to keep process awake
+func HerokuPing() {
+	pingInterval := time.NewTicker(time.Duration(5) * time.Minute)
+	for {
+		select {
+		case <-pingInterval.C:
+			logrus.Info("Pinging Heroku server")
+			http.Get("https://carlos-the-curious.herokuapp.com/status")
+		}
+	}
+}
+
 // Run is the entry point for Carlos to setup a connection with Slack and
 // the channels we use for listening and posting messages
 func (robot Robot) Run() {
 	if os.Getenv("PLATFORM") == "HEROKU" {
 		go HerokuServer()
+		go HerokuPing()
 	}
 
 	robot.SlackConnect()


### PR DESCRIPTION
When heroku doesn't get a connection for 5 min or more it puts the process in a sleep state. Since carlos doesn't have an webserver per se the process is always going to sleep. We now ping the server endpoint to keep the service awake and responsive.
