### PR TITLE
Fixup builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,28 @@
-from alpine:latest
+FROM golang:1.6-alpine
 
 MAINTAINER Dana Klassen <dana.klassen@shopify.com> 
 
-WORKDIR /opt
+ENV PROJECT /go/src/github.com/dklassen/CarlosTheCurious
+WORKDIR $PROJECT
 
-RUN apk add --update ca-certificates && \
-    rm -rf /var/cache/apk/* /tmp/*
+RUN mkdir -p $PROJECT
+COPY . $PROJECT
+
+RUN apk add --update ca-certificates
+RUN rm -rf /var/cache/apk/* /tmp/*
 
 RUN update-ca-certificates
 
-COPY .docker_build/carlos-the-curious bin/carlos-the-curious
+RUN apk update && \
+    apk upgrade && \
+    apk add bash \ 
+            git \
+            openssh
 
-COPY ./script/docker-entrypoint.sh /
+
+RUN go get github.com/tools/godep
+RUN godep go install -v 
 
 EXPOSE 5432
-ENTRYPOINT ["/docker-entrypoint.sh"]
 
+ENTRYPOINT $PROJECT/script/docker-entrypoint.sh

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -14,7 +14,7 @@
 		},
 		{
 			"ImportPath": "github.com/jinzhu/inflection",
-			"Rev": "3272df6c21d04180007eb3349844c89a3856bc25"
+			"Rev": "8f4d3a0d04ce0b7c0cf3126fb98524246d00d102"
 		},
 		{
 			"ImportPath": "github.com/lib/pq",

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,3 @@
-GO_BUILD_ENV := GOOS=linux GOARCH=amd64
-DOCKER_BUILD=$(shell pwd)/.docker_build
-DOCKER_CMD=$(DOCKER_BUILD)/carlos-the-curious
-
-
-$(DOCKER_CMD): clean
-	mkdir -p $(DOCKER_BUILD)
-	$(GO_BUILD_ENV) go build -v -o $(DOCKER_CMD) .
-
 build: $(DOCKER_CMD)
 	docker build -t carlos-the-curious .
 
@@ -15,6 +6,9 @@ clean:
 
 run:
 	docker run --net=host --rm -it -e "DATABASE_URL=$(DATABASE_URL)" -e "SLACKTOKEN=$(SLACKTOKEN)" carlos-the-curious
+
+console:
+	docker run -it --entrypoint /bin/bash carlos-the-curious
 
 database-up:
 	docker run -d --name carlos-postgres --net=host -p 5432:5432 postgres

--- a/README.md
+++ b/README.md
@@ -71,11 +71,10 @@ Lots left to do:
 
 ## Development
 
-First before ou doing anything setup Docker for Mac. Once up and running You can build the project via `make build`. This clean previous builds and create a new image for you. To use Carlos you will need to have a `postgres` database running somewhere. I would suggest using the postgres docker container which should setup everything at least for development.
+First before you doing anything setup Docker for Mac. Once up and running You can build the project via `make build`. This will build the project inside the container. To use Carlos you will need to have a `postgres` database running somewhere. I would suggest using the postgres docker container which should setup everything at least for development. You can set this up via `make database-build` which will create the container. You can run the container via `make database-up` and bring down with `make database-down`.
 
 Run the container with:
-`docker run -d --net=host --name carlos-postgres -p 5432:5432 postgres`.
+`DATABASE_URL={insert database URL} SLACK_TOKEN={insert your slack token} make run`
 
-Once the container is setup you can run the container with:
-
+But, If you want to trigger the container yourself:
 `docker run --net=host --rm -it -e "DATABASE_URL=postgres://postgres:@127.0.0.1/carlos?sslmode=disable" -e "SLACKTOKEN={{insert your slack token here}}" carlos-the-curious`

--- a/dev.yml
+++ b/dev.yml
@@ -6,7 +6,7 @@ up:
 commands:
   build: make build
   run: make run
-  console: docker run -it --entrypoint /bin/bash carlos-the-curious
+  console: make console
   database-up: docker run -d --name carlos-postgres --net=isolated_nw -p 5432:5432 postgres
   database-down: docker stop carlos-postgres
   database-build: docker build --tag carlos/postgres --file Dockerfile.devdb .

--- a/dev.yml
+++ b/dev.yml
@@ -4,8 +4,9 @@ up:
 - go: 1.6.2
 
 commands:
-  build: go build
-  run-built: ./carlos-the-curious
+  build: make build
+  run: make run
+  console: docker run -it --entrypoint /bin/bash carlos-the-curious
   database-up: docker run -d --name carlos-postgres --net=isolated_nw -p 5432:5432 postgres
   database-down: docker stop carlos-postgres
   database-build: docker build --tag carlos/postgres --file Dockerfile.devdb .

--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -xeo
 
-exec /opt/bin/carlos-the-curious --token=$SLACKTOKEN\
-                                 --database_url=$DATABASE_URL
+exec /go/bin/carlos-the-curious --token=$SLACKTOKEN\
+                                --database_url=$DATABASE_URL

--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -xeo
 
-exec /go/bin/carlos-the-curious --token=$SLACKTOKEN\
-                                --database_url=$DATABASE_URL
+exec CarlosTheCurious  --token=$SLACKTOKEN\
+                       --database_url=$DATABASE_URL

--- a/vendor/github.com/jinzhu/inflection/inflections.go
+++ b/vendor/github.com/jinzhu/inflection/inflections.go
@@ -66,6 +66,7 @@ var singularInflections = [][]string{
 	[]string{"([^aeiouy]|qu)ies$", "${1}y"},
 	[]string{"(s)eries$", "${1}eries"},
 	[]string{"(m)ovies$", "${1}ovie"},
+	[]string{"(c)ookies$", "${1}ookie"},
 	[]string{"(x|ch|ss|sh)es$", "${1}"},
 	[]string{"^(m|l)ice$", "${1}ouse"},
 	[]string{"(bus)(es)?$", "${1}"},


### PR DESCRIPTION
Originally we were building on the host and copying the binary into the container. Why not start building directly in the container. This PR updates the docker file to copy the project and do just that using godep to manage dependencies. We also switched from the barebones alpine to the golang:alpine image to standardize on. 

Added a make and dev command for jumping into the latest image build to check out whats going on in the image.
