### PR TITLE
Move entry point to cmd so we can run tests in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ RUN godep go install -v
 
 EXPOSE 5432
 
-ENTRYPOINT $PROJECT/script/docker-entrypoint.sh
+CMD $PROJECT/script/docker-entrypoint.sh

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 build: $(DOCKER_CMD)
 	docker build -t carlos-the-curious .
 
+local-test: 
+	godep go test ./slackbot
+
+test:
+	docker run --rm  --net=host -w /go/src/github.com/dklassen/CarlosTheCurious  carlos-the-curious go test ./slackbot
+
 clean:
 	rm -rf $(DOCKER_BUILD)
 


### PR DESCRIPTION
There seems to be a bug in docker were if an entrypoint is specified we can not run a container and get a "cannot locate binary". Modified the dockerfile to use CMD instead and updated the makefile to run tests in the container. We can further add this test step to the release cycle ( its kinda there during circle).
