### PR TITLE
Clean slackid recipient create

### DIFF
--- a/slackbot/conversation_test.go
+++ b/slackbot/conversation_test.go
@@ -37,12 +37,12 @@ func TestParseRecipientsText(t *testing.T) {
 			// Identify a single user and a channel with multiple users
 			Input: Message{Text: "<@UDF123> and <#C1U41SHTK|general>"},
 			InputChannels: map[string]Channel{
-				"C1U41SHTK": Channel{Members: []string{"derp1", "derp2"}},
+				"C1U41SHTK": Channel{Members: []string{"Uderp1", "Uderp2"}},
 			},
 			Expected: []Recipient{
 				{SlackID: "UDF123"},
-				{SlackID: "derp1"},
-				{SlackID: "derp2"},
+				{SlackID: "Uderp1"},
+				{SlackID: "Uderp2"},
 			},
 		},
 	}

--- a/slackbot/poll.go
+++ b/slackbot/poll.go
@@ -64,6 +64,15 @@ type Recipient struct {
 	SlackName string
 }
 
+func NewRecipient(id string) (*Recipient, error) {
+	idType := TypeOfSlackID(id)
+	if idType != UserID {
+		return nil, fmt.Errorf("A recipient must be ae user id not ", id)
+	}
+
+	return &Recipient{SlackID: id}, nil
+}
+
 func NewPoll(kind, creator, channel string) *Poll {
 	uuid := GenerateUUID()
 	return &Poll{

--- a/slackbot/poll.go
+++ b/slackbot/poll.go
@@ -67,7 +67,7 @@ type Recipient struct {
 func NewRecipient(id string) (*Recipient, error) {
 	idType := TypeOfSlackID(id)
 	if idType != UserID {
-		return nil, fmt.Errorf("A recipient must be a user id not ", id)
+		return nil, errors.New(fmt.Sprintf("A recipient must be a user id not ", id))
 	}
 
 	return &Recipient{SlackID: id}, nil

--- a/slackbot/poll.go
+++ b/slackbot/poll.go
@@ -67,7 +67,7 @@ type Recipient struct {
 func NewRecipient(id string) (*Recipient, error) {
 	idType := TypeOfSlackID(id)
 	if idType != UserID {
-		return nil, fmt.Errorf("A recipient must be ae user id not ", id)
+		return nil, fmt.Errorf("A recipient must be a user id not ", id)
 	}
 
 	return &Recipient{SlackID: id}, nil

--- a/slackbot/poll_test.go
+++ b/slackbot/poll_test.go
@@ -5,6 +5,32 @@ import (
 	"testing"
 )
 
+func TestNewRecipient(t *testing.T) {
+	var testingTable = []struct {
+		Input    string
+		Expected *Recipient
+	}{
+		{
+			Input:    "U123",
+			Expected: &Recipient{SlackID: "U123"},
+		},
+		{
+			Input:    "C123",
+			Expected: &Recipient{},
+		},
+	}
+
+	for _, test := range testingTable {
+		result, _ := NewRecipient(test.Input)
+		output := test.Expected
+
+		if strings.Compare(result.SlackID, output.SlackID) != 0 {
+			t.Fatal("Expected", output.SlackID, "got", result.SlackID)
+		}
+	}
+
+}
+
 func TestTransitionTo(t *testing.T) {
 	SetupTestDatabase()
 	poll := &Poll{Stage: "stage1", UUID: "1"}

--- a/slackbot/poll_test.go
+++ b/slackbot/poll_test.go
@@ -7,28 +7,36 @@ import (
 
 func TestNewRecipient(t *testing.T) {
 	var testingTable = []struct {
-		Input    string
-		Expected *Recipient
+		Input         string
+		Expected      *Recipient
+		ExpectedError bool
 	}{
 		{
-			Input:    "U123",
-			Expected: &Recipient{SlackID: "U123"},
+			Input:         "U123",
+			Expected:      &Recipient{SlackID: "U123"},
+			ExpectedError: false,
 		},
 		{
-			Input:    "C123",
-			Expected: &Recipient{},
+			Input:         "C123",
+			Expected:      &Recipient{},
+			ExpectedError: true,
 		},
 	}
 
 	for _, test := range testingTable {
-		result, _ := NewRecipient(test.Input)
+		result, err := NewRecipient(test.Input)
 		output := test.Expected
+
+		if test.ExpectedError && err == nil {
+			t.Fatal("Expected error", err)
+		} else {
+			continue
+		}
 
 		if strings.Compare(result.SlackID, output.SlackID) != 0 {
 			t.Fatal("Expected", output.SlackID, "got", result.SlackID)
 		}
 	}
-
 }
 
 func TestTransitionTo(t *testing.T) {

--- a/slackbot/slack.go
+++ b/slackbot/slack.go
@@ -36,8 +36,8 @@ type SlackID struct {
 
 type SlackIDType int
 
-func (id *SlackID) Kind() SlackIDType {
-	switch string(id.Value[0]) {
+func TypeOfSlackID(id string) SlackIDType {
+	switch string(id[0]) {
 	case "G":
 		return GroupChannelID
 	case "C":
@@ -45,7 +45,6 @@ func (id *SlackID) Kind() SlackIDType {
 	case "U":
 		return UserID
 	default:
-		logrus.Error("Unable to identify the kind of channel from id:", id.Value)
 		return UnknownID
 	}
 }


### PR DESCRIPTION
Cleaning up creating new recipients. There was a step where for some reason we has a slackID struct and checked the kind of id it was. Theres no real reason for that we can split that out into a separate function to check the id string instead.
