### PR TITLE
Missing a dash as an acceptable char in a slackgroup id

### DIFF
--- a/slackbot/conversation.go
+++ b/slackbot/conversation.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	slackIDRegex            = regexp.MustCompile("<@([a-zA-Z0-9]+)>")
-	slackPublicGroupIDRegex = regexp.MustCompile("<#([a-zA-Z0-9]+)[|]{1}[a-zA-Z0-9]+>")
+	slackPublicGroupIDRegex = regexp.MustCompile("<#([a-zA-Z0-9]+)[|]{1}[a-zA-Z0-9-]+>")
 	stageLookup             = map[string]Stage{
 		"initial":       getQuestion,
 		"getAnswers":    getAnswers,

--- a/slackbot/conversation_test.go
+++ b/slackbot/conversation_test.go
@@ -35,7 +35,7 @@ func TestParseRecipientsText(t *testing.T) {
 		},
 		{
 			// Identify a single user and a channel with multiple users
-			Input: Message{Text: "<@UDF123> and <#C1U41SHTK|general>"},
+			Input: Message{Text: "<@UDF123> and <#C1U41SHTK|general-1>"},
 			InputChannels: map[string]Channel{
 				"C1U41SHTK": Channel{Members: []string{"Uderp1", "Uderp2"}},
 			},


### PR DESCRIPTION
channels can have dashes.
